### PR TITLE
Remove 'src' attriute from legend template

### DIFF
--- a/index.html
+++ b/index.html
@@ -228,7 +228,7 @@
 
 		<template id="legend-list-entry">
 			<li class="flex flex-col lg:flex-row items-center mb-2 last:mb-0">
-				<img src="to_be_set" alt="" class="w-12 h-12 mr-4" />
+				<img alt="" class="w-12 h-12 mr-4" />
 				<span class="text-sm">description</span>
 			</li>
 		</template>


### PR DESCRIPTION
Fixed #148.

Ich habe das src Attribut einfach rausgenommen. Karte funktioniert weiterhin, es gibt auch keine Fehler in der Konsole. Es stellte sich als albern kompliziert heraus mittels vite im HTML Code assets zu referenzieren :roll_eyes: 