### PR TITLE
Use GitHub CODEOWNERS for dependabot reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# As per the team configuration, this will assign one of us to be the reviewer
+# for incoming pull requests. If you want to change that, feel free to do this
+# in the team settings.
+* @Queer-Lexikon/karte

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,15 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    reviewers:
-      - nachtjasmin
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
-    reviewers:
-      - nachtjasmin
     groups:
       all:
         patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,12 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
       all:
         patterns: ["*"]


### PR DESCRIPTION
Frage nach Feedback an dieser Stelle: @xenein, @schroedingersZombie (ergänzt gern noch weitere) macht es vllt. Sinn in der Orga ne entsprechende Gruppe anzulegen, so wie es dieses PR in der `CODEOWNERS` vorsieht?

Oder wollen wir da einfach die entsprechenden devs einzeln auflisten?